### PR TITLE
Date selector should show current date.

### DIFF
--- a/src/ConfigurationProvider.js
+++ b/src/ConfigurationProvider.js
@@ -76,7 +76,7 @@ const CONFIGS = [
       },
     ],
     strings: {
-      headerText: "East-African Community",
+      headerText: "East African Community",
     },
     features: {
       exampleFeature: true,

--- a/src/util.js
+++ b/src/util.js
@@ -133,7 +133,7 @@ export const changeDates = (
   setSelectedDateIndex
 ) => {
   // Add any missing dates between the last available date and the current date.
-  let date = new Date(newDates[newDates.length - 1]),
+  let date = new Date(newDates[newDates.length - 1] + 'T23:59:59Z'),
       today = new Date();
 
   const dates = newDates.slice();


### PR DESCRIPTION
## Overview

This modifies the logic that extends the data dates to the current date. Prior to this the logic was such that in the early morning the comparison of the incremental date would produce an incorrect date in the date selector.

Also, change the title name of the EAC dashboard to be consistent with how they display their full name on their website.


